### PR TITLE
I fixed a SyntaxError in `dicom_viewer_3d.py` by removing an artifact…

### DIFF
--- a/rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py
+++ b/rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py
@@ -470,5 +470,3 @@ if __name__ == '__main__':
     viewer3d.resize(800, 600)
     viewer3d.show()
     sys.exit(app.exec_())
-
-[end of rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py]


### PR DESCRIPTION
… line.

I removed an extraneous line `[end of rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py]` that was accidentally inserted at the end of the file, causing a SyntaxError on startup. This was an artifact from a previous file manipulation operation.

The code should now correctly be set up for the 2D slice visibility test in the 3D viewer.