### PR TITLE
I've addressed a SyntaxError in `dicom_viewer_3d.py` by removing an u…

### DIFF
--- a/rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py
+++ b/rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py
@@ -458,5 +458,3 @@ if __name__ == '__main__':
     viewer3d.resize(800, 600)
     viewer3d.show()
     sys.exit(app.exec_())
-
-[end of rad-ui-upd30/QRadPlannerApp/ui/dicom_viewer_3d.py]


### PR DESCRIPTION
…nnecessary line.

It seems an extraneous line, `[end of ...]`, found its way back into the end of the `dicom_viewer_3d.py` file. This was causing a SyntaxError when the application started.

I've now ensured the file is clean, so the application should start without issues. This will allow you to test the intended vtkSmartVolumeMapper configuration.